### PR TITLE
fix(client): same-origin API/socket in prod

### DIFF
--- a/client/.env.development
+++ b/client/.env.development
@@ -1,0 +1,4 @@
+# Dev only (CRA loads this in `npm start`, NOT in production build).
+# Points the client at the local API/socket server. In production API_URL is
+# empty so the client uses the same origin as the served page.
+REACT_APP_API_URL=http://localhost:3001

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,6 +6,10 @@ import DocumentUpload from './components/DocumentUpload';
 import TranslationProgress from './components/TranslationProgress';
 import DocumentPreview from './components/DocumentPreview';
 
+// API origin: пусто => тот же origin, что и страница (прод, через Traefik).
+// В dev задаётся через client/.env.development (REACT_APP_API_URL=http://localhost:3001).
+const API_URL = process.env.REACT_APP_API_URL || '';
+
 function App() {
   const [translationState, setTranslationState] = React.useState({
     status: 'idle',
@@ -27,7 +31,7 @@ function App() {
 
   // Инициализация WebSocket соединения
   useEffect(() => {
-    const newSocket = io('http://localhost:3001', { query: { sessionId } });
+    const newSocket = io(API_URL || window.location.origin, { query: { sessionId } });
     setSocket(newSocket);
 
     return () => newSocket.close();
@@ -85,7 +89,7 @@ function App() {
       formData.append('sourceLang', 'he'); // Исходный язык всегда иврит
       formData.append('sessionId', sessionId);
 
-      const response = await fetch('http://localhost:3001/api/translate', {
+      const response = await fetch(`${API_URL}/api/translate`, {
         method: 'POST',
         body: formData,
       });


### PR DESCRIPTION
Fixes upload error in production: client was hardcoded to http://localhost:3001 (mixed-content blocked from the https page). Now uses same-origin (REACT_APP_API_URL empty => current origin) for fetch + socket.io. Adds client/.env.development for local dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)