### PR TITLE
feat: Groq (free) primary for translation

### DIFF
--- a/litellm/config.yaml
+++ b/litellm/config.yaml
@@ -1,20 +1,20 @@
-# Phase 0 default: Gemini 2.0 Flash (free tier) is PRIMARY for `translate`,
-# Claude (OpenRouter) is the FALLBACK. Rationale: the OpenRouter key currently
-# has no credits. To restore Claude-primary (design preference) once OpenRouter
-# is funded, swap the `translate` and `translate-claude` model bodies below.
+# `translate` PRIMARY = Groq Llama 3.3 70B (free tier); FALLBACK = Claude via
+# OpenRouter (`translate-claude`, paid — only used if Groq fails/rate-limits).
+# `detect` = Groq Llama 3.1 8B (fast/cheap). Gemini was dropped: the operator's
+# Gemini project had depleted prepay credits (429 RESOURCE_EXHAUSTED).
 model_list:
   - model_name: translate
     litellm_params:
-      model: gemini/gemini-2.0-flash
-      api_key: os.environ/GEMINI_API_KEY
+      model: groq/llama-3.3-70b-versatile
+      api_key: os.environ/GROQ_API_KEY
   - model_name: translate-claude
     litellm_params:
       model: openrouter/anthropic/claude-sonnet-4
       api_key: os.environ/OPENROUTER_API_KEY
   - model_name: detect
     litellm_params:
-      model: gemini/gemini-2.0-flash
-      api_key: os.environ/GEMINI_API_KEY
+      model: groq/llama-3.1-8b-instant
+      api_key: os.environ/GROQ_API_KEY
 litellm_settings:
   num_retries: 2
   request_timeout: 60


### PR DESCRIPTION
Switch translate alias to Groq Llama 3.3 70B (free tier); Claude via OpenRouter remains fallback. Gemini dropped (operator project prepay depleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)