### PR TITLE
fix: pipeline resilience + Groq-friendly batching

### DIFF
--- a/server/adapters/ai/LiteLLMProvider.js
+++ b/server/adapters/ai/LiteLLMProvider.js
@@ -16,6 +16,8 @@ class LiteLLMProvider extends AIProvider {
     this.apiKey = options.apiKey || process.env.LITELLM_MASTER_KEY;
     this.model = options.model || 'translate';
     this.timeout = options.timeout || 30000;
+    // Batch translation needs a longer budget: Groq + litellm retries/fallback.
+    this.batchTimeout = options.batchTimeout || 120000;
   }
 
   /**
@@ -146,7 +148,9 @@ If text contains mixed languages, translate only the ${langNames[from]} parts.`;
    */
   async translateBatchAligned(segments, from, to) {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+    // Batch-specific (larger) timeout, not the 30s single-call timeout.
+    const timeout = this.batchTimeout || 120000;
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
 
     let response;
     try {

--- a/server/api/translate.js
+++ b/server/api/translate.js
@@ -76,7 +76,8 @@ documentQueue.process('translate', async (job) => {
     const doc = await buildTranslationDocument(
       { blocks: docBlocks, segments },
       (chunk) => aiProvider.translateBatchAligned(chunk, sourceLang || 'he', targetLang),
-      { sourceLang: sourceLang || 'he', targetLang, maxSegments: MAX_SEGMENTS, concurrency: 3,
+      { sourceLang: sourceLang || 'he', targetLang, maxSegments: MAX_SEGMENTS,
+        concurrency: 2, maxPerChunk: 8, maxTokens: 1200,
         owner: 'anon', jobId: String(job.id), ts: Date.now(),
         onCap: (info) => console.warn(`Segment cap hit: ${info.total} > ${info.cap} (job ${job.id})`) }
     );

--- a/server/services/__tests__/pipeline.test.js
+++ b/server/services/__tests__/pipeline.test.js
@@ -50,4 +50,21 @@ describe('buildTranslationDocument', () => {
     expect(doc.blocks[0].sentences[0].target).toBe('W');   // translated
     expect(doc.blocks[0].sentences[4].target).toBe('w');   // capped -> source
   });
+  it('a failing chunk degrades to source passthrough, job still completes', async () => {
+    const seg = (id, toks) => ({ id, source: toks.join(' '), srcTokens: toks });
+    const blocks = [{ id:'b0', type:'paragraph', sentences:[ seg('b0s0',['a']), seg('b0s1',['b']) ] }];
+    // force tiny chunks so each segment is its own chunk; first chunk throws, second ok
+    let call = 0;
+    const flakyBatch = async (chunk) => {
+      call++;
+      if (call === 1) throw new Error('groq timeout');
+      return { items: chunk.map(s => ({ id:s.id, target:'OK', align:[] })), usage:null };
+    };
+    const doc = await buildTranslationDocument({ blocks, segments: blocks[0].sentences }, flakyBatch,
+      { sourceLang:'he', targetLang:'en', maxPerChunk: 1, concurrency: 1 });
+    const s = doc.blocks[0].sentences;
+    // first segment failed -> source passthrough; second -> translated
+    expect(s[0].target).toBe('a');
+    expect(s[1].target).toBe('OK');
+  });
 });

--- a/server/services/pipeline.js
+++ b/server/services/pipeline.js
@@ -64,19 +64,35 @@ function chunkSegments(segments, { maxPerChunk = 18, maxTokens = 1500 } = {}) {
 /**
  * Process chunks through `translateBatch` in waves of `concurrency`, returning
  * the flat array of per-chunk results in chunk order.
+ *
+ * Graceful degradation: a chunk that throws (Groq timeout / rate-limit /
+ * litellm failure) or returns falsy is treated as an empty result
+ * `{ items: [], usage: null }`. Its segments then fall through to source
+ * passthrough via the missing-item logic in `buildTranslationDocument`. A single
+ * failed chunk must NEVER fail the whole job.
+ *
+ * @param {Function} [onChunkError] optional (err, chunkIndex) callback
  */
-async function translateChunks(chunks, translateBatch, concurrency) {
+async function translateChunks(chunks, translateBatch, concurrency, onChunkError) {
   const width = Math.max(1, concurrency | 0);
   const results = [];
 
   for (let i = 0; i < chunks.length; i += width) {
     const wave = chunks.slice(i, i + width);
     const settled = await Promise.all(
-      wave.map((chunk) =>
-        translateBatch(
-          chunk.map((s) => ({ id: s.id, source: s.source, srcTokens: s.srcTokens })),
-        ),
-      ),
+      wave.map(async (chunk, j) => {
+        try {
+          const r = await translateBatch(
+            chunk.map((s) => ({ id: s.id, source: s.source, srcTokens: s.srcTokens })),
+          );
+          return r || { items: [], usage: null };
+        } catch (err) {
+          if (typeof onChunkError === 'function') {
+            try { onChunkError(err, i + j); } catch { /* ignore logging errors */ }
+          }
+          return { items: [], usage: null };
+        }
+      }),
     );
     for (const r of settled) results.push(r);
   }
@@ -101,11 +117,12 @@ async function buildTranslationDocument(structure, translateBatch, opts = {}) {
     sourceLang,
     targetLang,
     maxSegments = 1500,
-    concurrency = 3,
+    concurrency = 2,
     owner = 'anon',
     jobId = null,
     ts = null,
     onCap = null,
+    onChunkError = null,
   } = opts;
 
   // Segment cap: only the first `maxSegments` are translated; the rest pass
@@ -118,9 +135,13 @@ async function buildTranslationDocument(structure, translateBatch, opts = {}) {
     }
   }
 
-  // Chunk + translate with bounded concurrency.
-  const chunks = chunkSegments(toTranslate, opts);
-  const chunkResults = await translateChunks(chunks, translateBatch, concurrency);
+  // Chunk + translate with bounded concurrency. Chunk sizing is tunable so
+  // smaller, Groq-friendly batches can be requested by the caller.
+  const chunks = chunkSegments(toTranslate, {
+    maxPerChunk: opts.maxPerChunk || 8,
+    maxTokens: opts.maxTokens || 1200,
+  });
+  const chunkResults = await translateChunks(chunks, translateBatch, concurrency, onChunkError);
 
   // Aggregate usage and build id -> item map.
   const usage = newUsage();


### PR DESCRIPTION
Graceful per-chunk degradation (a failed chunk no longer fails the whole job), larger batch timeout (120s), smaller chunks (8) + lower concurrency (2) for Groq free-tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)